### PR TITLE
Fix typo in WorkerPool config

### DIFF
--- a/internal/handlers/v1/tasks/routes.go
+++ b/internal/handlers/v1/tasks/routes.go
@@ -16,7 +16,7 @@ var pool *worker.WorkerPool
 
 func init() {
 	pool = &worker.WorkerPool{
-		Concurreny:   10,
+		Concurrency:  10,
 		LogPath:      "logs",
 		DatabasePath: "tasks.db",
 	}


### PR DESCRIPTION
## Summary
- correct `Concurreny` field typo to `Concurrency`

## Testing
- `go vet ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686aecf90c3c8323969b17d06b8559df