### PR TITLE
Update README port instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ It serves as a central, versioned entry point for handling requests, managing ta
 go run ./cmd/main.go
 ```
 
+The server listens on port `8080` by default. Set the `PORT` environment
+variable to override this when running locally.
+
 Or use the dev container:
 
 ```bash


### PR DESCRIPTION
## Summary
- note that the server defaults to port 8080
- explain how to override with the PORT environment variable

## Testing
- `go vet ./...` *(fails: proxy blocked)*
- `go test ./...` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686aed0f21648323af02114143e37b73